### PR TITLE
Add automatic unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,3 +46,9 @@ jobs:
         python -m pip install emcee
         # TODO: Currently, we need to specify the directory. This should not be necessary in the future once all tests are compatible with pytest.
         python -m pytest tests --cov=desilike --durations=0 --cov-report lcov
+    - name: Coverage with Coveralls
+      if: ${{ success() && ( matrix.python-version == '3.13' ) && ( matrix.os == 'ubuntu-latest' ) }}
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage.lcov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,11 @@ jobs:
         ruff check desilike --ignore E701,E721,F401,E711,F811,E402,F841,E714,E731,F541,F405,F403,E722,F523,E741,F601,E401,E713,F524
     - name: Test with pytest
       run: |
+         if [ "$RUNNER_OS" == "Linux" ]; then
+              apt install libopenmpi-dev
+         else
+              brew install openmpi
+         fi
         python -m pip install .
         # TODO: Create pyproject.toml with test requirements and remove this line.
         python -m pip install emcee

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: tests
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ruff pytest pytest-cov
+    - name: Lint with ruff
+      run: |
+        ruff check desilike

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,11 +36,11 @@ jobs:
         ruff check desilike --ignore E701,E721,F401,E711,F811,E402,F841,E714,E731,F541,F405,F403,E722,F523,E741,F601,E401,E713,F524
     - name: Test with pytest
       run: |
-         if [ "$RUNNER_OS" == "Linux" ]; then
-              apt install libopenmpi-dev
-         else
-              brew install openmpi
-         fi
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          apt install libopenmpi-dev
+        else
+          brew install openmpi
+        fi
         python -m pip install .
         # TODO: Create pyproject.toml with test requirements and remove this line.
         python -m pip install emcee

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Test with pytest
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
-          apt install libopenmpi-dev
+          sudo apt install libopenmpi-dev
         else
           brew install openmpi
         fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,12 @@ jobs:
         python -m pip install ruff pytest pytest-cov
     - name: Lint with ruff
       run: |
-        ruff check desilike
+        # TODO: Ultimately, all checks should work.
+        ruff check desilike --ignore E701,E721,F401,E711,F811,E402,F841,E714,E731,F541,F405,F403,E722,F523,E741,F601,E401,E713,F524
+    - name: Test with pytest
+      run: |
+        python -m pip install .
+        # TODO: Create pyproject.toml with test requirements and remove this line.
+        python -m pip install emcee
+        # TODO: Currently, we need to specify the directory. This should not be necessary in the future once all tests are compatible with pytest.
+        python -m pytest tests --cov=desilike --durations=0 --cov-report lcov

--- a/desilike/profilers/scipy.py
+++ b/desilike/profilers/scipy.py
@@ -99,6 +99,7 @@ class ScipyProfiler(BaseProfiler):
         return super(ScipyProfiler, self).maximize(*args, **kwargs)
 
     def _maximize_one(self, state, max_iterations=int(1e5), tol=None, **kwargs):
+        profiles = Profiles()
         from scipy import optimize
         bounds = [tuple(None if np.isinf(lim) else lim for lim in param.prior.limits) for param in state.varied_params]
         kw = {}
@@ -112,7 +113,6 @@ class ScipyProfiler(BaseProfiler):
             return profiles
         if not result.success and self.mpicomm.rank == 0:
             self.log_error('Finished unsuccessfully.')
-        profiles = Profiles()
         attrs = {name: getattr(result, name) for name in ['success', 'status', 'message', 'nit']}
         profiles.set(bestfit=ParameterBestFit([np.atleast_1d(xx) for xx in result.x] + [- 0.5 * np.atleast_1d(result.fun)], params=state.varied_params + ['logposterior']), attrs=attrs)
         if getattr(result, 'hess_inv', None) is not None:

--- a/desilike/theories/tests/test_galaxy_clustering.py
+++ b/desilike/theories/tests/test_galaxy_clustering.py
@@ -1450,7 +1450,7 @@ def test_emulator_direct():
         cosmo = Cosmoprimo()
         for param in cosmo.init.params.select(fixed=False):
             param.update(fixed=True)
-        for param in values:
+        for param in param_values:
             cosmo.init.params[param].update(fixed=False)
         template = DirectPowerSpectrumTemplate(cosmo=cosmo, k=np.linspace(0.001, 0.3, 100))
         #t0 = time.time()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name=package_basename,
       description='Package for DESI likelihoods',
       license='BSD3',
       url='http://github.com/cosmodesi/desilike',
-      install_requires=['numpy', 'scipy', 'pyyaml', 'mpi4py', 'cosmoprimo @ git+https://github.com/cosmodesi/cosmoprimo'],
+      install_requires=['numpy==1.26.4', 'scipy', 'pyyaml', 'mpi4py', 'cosmoprimo @ git+https://github.com/cosmodesi/cosmoprimo'],
       extras_require={'plotting': ['matplotlib', 'tabulate', 'getdist', 'anesthetic @ git+https://github.com/handley-lab/anesthetic'], 'jax': ['jax', 'interpax @ git+https://github.com/adematti/interpax']},
       packages=find_packages(),
       package_data={package_basename: list(get_yaml_files()) + ['emulators/train/*/emulator.*']})

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name=package_basename,
       description='Package for DESI likelihoods',
       license='BSD3',
       url='http://github.com/cosmodesi/desilike',
-      install_requires=['numpy==1.26.4', 'scipy', 'pyyaml', 'mpi4py', 'cosmoprimo @ git+https://github.com/cosmodesi/cosmoprimo'],
+      install_requires=['numpy<2.0.0', 'scipy', 'pyyaml', 'mpi4py', 'cosmoprimo @ git+https://github.com/cosmodesi/cosmoprimo'],
       extras_require={'plotting': ['matplotlib', 'tabulate', 'getdist', 'anesthetic @ git+https://github.com/handley-lab/anesthetic'], 'jax': ['jax', 'interpax @ git+https://github.com/adematti/interpax']},
       packages=find_packages(),
       package_data={package_basename: list(get_yaml_files()) + ['emulators/train/*/emulator.*']})

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+
+from desilike.base import BaseCalculator
+from desilike.likelihoods import BaseGaussianLikelihood
+from desilike.samplers import EmceeSampler
+
+
+@pytest.fixture
+def simple_likelihood():
+
+    class Model(BaseCalculator):
+
+        _params = dict(a=dict(prior=dict(dist='uniform', limits=[0, 1])),
+                       b=dict(prior=dict(dist='uniform', limits=[0, 1])))
+
+        def initialize(self, x=None):
+            pass
+
+        def calculate(self, a=0., b=0.):
+            self.y = np.array([a, b])
+
+    class Likelihood(BaseGaussianLikelihood):
+
+        def initialize(self):
+            super(Likelihood, self).initialize(
+                np.array([0.4, 0.6]), covariance=np.eye(2) * 0.01)
+            self.theory = Model()
+
+        @property
+        def flattheory(self):
+            return self.theory.y
+
+    return Likelihood()
+
+
+@pytest.mark.parametrize("Sampler", [EmceeSampler])
+def test_basic(simple_likelihood, Sampler):
+    # Test that all samplers work with a simple two-dimensional likelihood.
+
+    sampler = Sampler(simple_likelihood, seed=42)
+    chain = sampler.run(check=True)[0].remove_burnin(0.5)
+
+    assert np.allclose(
+        chain.mean(sampler.varied_params), simple_likelihood.flatdata,
+        atol=0.03, rtol=0)
+    assert np.allclose(
+        chain.std(sampler.varied_params), np.sqrt(np.diag(np.linalg.inv(
+            simple_likelihood.precision))), atol=0.01, rtol=0.1)
+    assert np.allclose(
+        chain.covariance(sampler.varied_params), np.linalg.inv(
+            simple_likelihood.precision), atol=0.01, rtol=0.1)


### PR DESCRIPTION
This PR adds basic unit tests with `pytest` and syntax checks with `ruff`. For now, only the emcee sampler is tested but this will be expanded soon. Similarly, there are a large number of exceptions for the `ruff` check but we should try to follow syntax rules more in the future.

I also found (with the help of ruff) one minor, practically irrelevant issue that looked like a bug in `desilike/profilers/scipy.py`. Finally, to run the tests I needed to fix numpy to <2.0.0 for now.