### PR TITLE
update act dr6 lensing likelihood

### DIFF
--- a/desilike/likelihoods/cmb/act_dr6_lensing.yaml
+++ b/desilike/likelihoods/cmb/act_dr6_lensing.yaml
@@ -1,3 +1,15 @@
 class: ACTDR6LensingLikelihood
 
 params:
+  Alens:
+    prior:
+      dist: norm
+      loc: 1
+      scale: 0.005
+    ref:
+      dist: norm
+      loc: 1.013
+      scale: 0.023
+    proposal: 0.0005
+    delta: 0.0005
+    latex: A_\mathrm{lens}


### PR DESCRIPTION
I update the following two things: 

- `Alens` is now treated as a parameter
- Change the super class of `ACTDR6LensingLikelihood` from `BaseGaussianLikelihood` to `BaseLikelihood` in order to avoid the following error during the sampling: _param_loglikelihood is not an attribute of the likelihood.