### PR TITLE
Fix: add numpy>=1.25 constraint to jax optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ plotting = [
     "getdist",
     "anesthetic"]
 jax = [
+    "numpy>=1.25",
     "jax",
     "interpax"]
 


### PR DESCRIPTION
## Fix: add numpy>=1.25 constraint to jax optional dependencies

JAX requires NumPy >= 1.25 (which introduced `numpy.dtypes`), but the `[jax]` optional dependency group in `pyproject.toml` does not declare this constraint. Since optional dependencies do not automatically tighten the version bounds of core dependencies, users with NumPy < 1.25 installed encounter an `AttributeError` at runtime:

```
AttributeError: module 'numpy' has no attribute 'dtypes'
```

This PR adds `numpy>=1.25` to the `[jax]` extras group to ensure the correct version is installed when JAX support is requested.

### Changes
- `pyproject.toml`: add `numpy>=1.25` to `[project.optional-dependencies] jax`